### PR TITLE
🐛 fixing bug in docker tag naming - closes #99

### DIFF
--- a/scripts/docker
+++ b/scripts/docker
@@ -13,5 +13,5 @@ then
 else
     echo info::docker:: branch $BRANCH is not master, building without version increment
     docker pull nginx:stable
-    docker build . -t myspecialway/msw-portal:$(echo $BRANCH | sed 's/\///g')
+    docker build . -t myspecialway/msw-portal:$(echo $BRANCH | ./scripts/helpers/version-fixer)
 fi

--- a/scripts/docker-push
+++ b/scripts/docker-push
@@ -10,5 +10,5 @@ then
     docker push myspecialway/msw-portal:latest
 else
     echo info::docker-push:: branch is not \"master\" pushing custom branch docker tag
-    docker push myspecialway/msw-portal:$(echo $BRANCH | sed 's/\///g')
+    docker push myspecialway/msw-portal:$(echo $BRANCH | ./scripts/helpers/version-fixer)
 fi

--- a/scripts/helpers/version-fixer
+++ b/scripts/helpers/version-fixer
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+read BRANCH_NAME
+
+echo $BRANCH_NAME | sed 's/[\/#-]/_/g'


### PR DESCRIPTION
Fixing The same bug as was in server with docker tags names to support `#` sigh