### PR TITLE
Bugfix/student schedule update is destructive 258

### DIFF
--- a/src/app/models/student.model.ts
+++ b/src/app/models/student.model.ts
@@ -8,8 +8,7 @@ export default class Student {
   firstname: string;
   lastname: string;
   gender: Gender;
-  class?: Class;
-  class_id: string;
+  class: Class;
   schedule: TimeSlot[];
 }
 

--- a/src/app/models/timeslot.model.ts
+++ b/src/app/models/timeslot.model.ts
@@ -4,4 +4,5 @@ export interface TimeSlot {
   index: string;
   lesson?: Lesson;
   location?: Location;
+  customized?: boolean;
 }

--- a/src/app/pages/student/details/tabs/student-details-hours/student-details-hours.component.ts
+++ b/src/app/pages/student/details/tabs/student-details-hours/student-details-hours.component.ts
@@ -69,6 +69,10 @@ export class StudentDetailsHoursComponent implements OnInit {
       if (!data) {
         return;
       }
+      const onlyCustomizedSlots: TimeSlot[] = this.student.schedule.filter((slot) => slot.customized);
+      const newCustomizedSlot: TimeSlot = { index: data.index, lesson: data.lesson, location: data.location, customized: true };
+      const newCustomizedSchedule = [...onlyCustomizedSlots, newCustomizedSlot];
+
       const tempStudent: StudentQuery = {
         _id: this.student._id,
         username: this.student.username,
@@ -76,8 +80,8 @@ export class StudentDetailsHoursComponent implements OnInit {
         lastname: this.student.lastname,
         gender: this.student.gender,
         password: this.student.password,
-        class_id: this.student.class_id,
-        schedule: [{ index: data.index, lesson: data.lesson, location: data.location }],
+        class_id: this.student.class._id,
+        schedule: newCustomizedSchedule,
       };
       try {
         await this.studentService.update(tempStudent);

--- a/src/app/pages/student/details/tabs/student-details-personal-info/student-details-personal-info.component.html
+++ b/src/app/pages/student/details/tabs/student-details-personal-info/student-details-personal-info.component.html
@@ -33,7 +33,7 @@
         </div>
 
         <mat-form-field class="classname">
-          <mat-select placeholder="כיתה" [(ngModel)]="student.class_id" #classId="ngModel" name="class_id" required>
+          <mat-select placeholder="כיתה" [(ngModel)]="student.class._id" #classId="ngModel" name="class_id" required>
             <mat-option *ngFor="let classname of classes" [value]="classname._id">
               {{classname.name}}
             </mat-option>

--- a/src/app/pages/student/services/student.graphql.service.ts
+++ b/src/app/pages/student/services/student.graphql.service.ts
@@ -93,7 +93,7 @@ export class StudentService {
             firstname: "${student.firstname}"
             lastname: "${student.lastname}"
             gender: ${student.gender}
-            class_id: "${student.class_id}"
+            class_id: "${student.class._id}"
             }) { _id }
         }
     `,

--- a/src/app/pages/student/services/student.graphql.ts
+++ b/src/app/pages/student/services/student.graphql.ts
@@ -40,6 +40,7 @@ export const QUERY_GET_STUDENT_BY_ID = gql`
             floor
           }
         }
+        customized
       }
       class {
         name

--- a/src/app/pages/student/services/student.service.ts
+++ b/src/app/pages/student/services/student.service.ts
@@ -48,7 +48,7 @@ export class StudentService {
     return this.apollo
       .mutate({
         mutation: MUTATE_ADD_STUDENT,
-        variables: { student: { ...student, class: undefined, class_id: student.class_id } },
+        variables: { student: { ...student, class: undefined, class_id: student.class._id } },
         refetchQueries: [{ query: QUERY_GET_ALL_STUDENTS }],
       })
       .toPromise();


### PR DESCRIPTION
This PR is dependant on server PR 
https://github.com/myspecialway/my-special-way-server/pull/87

Changes: 
1. Differentiating student-only time slots from class schedule items, by using new "customized" flag.
2. Now we can save more than one updated slot along wit student data, thanks to a new merge strategy: in short, we re-save only the marked ("customized": true) slot