### PR TITLE
event: adding new slot to a student customized schedule break previous slots, therefore not shown on the client

### DIFF
--- a/src/app/pages/student/services/student.graphql.ts
+++ b/src/app/pages/student/services/student.graphql.ts
@@ -27,15 +27,21 @@ export const QUERY_GET_STUDENT_BY_ID = gql`
       gender
       schedule {
         index
+        hours
         lesson {
+          _id
           title
           icon
         }
         location {
+          _id
           name
+          location_id
           position {
             floor
           }
+          icon
+          type
         }
         customized
       }


### PR DESCRIPTION
bug: upon new addition, the previous customized slots are being sent incomplete to the server, therefore not reflected/shown on the client.
fix: adding missing fields in  gql